### PR TITLE
Improve pre-commit behavior and add local setup guide to Contributing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,10 @@ repos:
     rev: "v3.6.2"
     hooks:
       - id: prettier
-        entry: env CI=1 bash -c "prettier --list-different . || ec=$? && prettier --loglevel=error --write . && exit $ec"
-        pass_filenames: false
-        args: []
+        args:
+          - --log-level=error
+          - --ignore-path=.prettierignore
+          - --write
         additional_dependencies:
           - prettier
           - prettier-plugin-toml

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,7 @@ collections/
 # WIP
 tests/integration/targets/ios_config/templates/config.js
 README.md
+CISCO_README.md
+
+# Archive files
+archive/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ remarks or suggestions can help.
 3. Make your changes.
 4. Check that everything works for Eltex (if you have the opportunity to test).
 5. Submit a Pull Request with a clear title and description:
-    - What exactly you are changing.
-    - For which Eltex models/versions.
-    - Usage examples.
+   - What exactly you are changing.
+   - For which Eltex models/versions.
+   - Usage examples.
 
 ## 📄 Code / Style / Structure
 
@@ -47,6 +47,40 @@ When opening an issue:
 - Specify the device model and firmware version.
 - Steps to reproduce or a reproducible playbook.
 - Expected behavior vs. actual behavior.
+
+## 🔧 Enable pre-commit locally
+
+To run the same checks locally as in CI:
+
+1. Ensure Python is available, then install pre-commit in your **virtualenv**:
+
+   ```bash
+   python -m pip install pre-commit
+   ```
+
+2. Install the git hook scripts:
+
+   ```bash
+   pre-commit install
+   ```
+
+3. (Optional) Update hooks to the latest compatible versions:
+
+   ```bash
+   pre-commit autoupdate
+   ```
+
+4. Run all checks on the whole repo before committing:
+
+   ```bash
+   pre-commit run --all-files
+   ```
+
+Notes:
+
+- pre-commit runs automatically on commit after step 2.
+- If a hook reformats files, re-stage the changes and commit again.
+- Some hooks respect ignore files like `.prettierignore`.
 
 ## 🔖 License
 


### PR DESCRIPTION
**Changes:**

- Make Prettier respect .prettierignore by removing pass_filenames: false in .pre-commit-config.yaml.
- Keep Prettier args minimal and aligned with default behavior (filenames passed by pre-commit).
- Add a “Enable pre-commit locally” section to CONTRIBUTING.md with quick steps.

Closes #5