### PR TITLE
Split release workflow into two jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,16 @@ on: # yamllint disable-line rule:truthy
   release:
     types: [published]
 jobs:
-  release:
-    uses: ansible/ansible-content-actions/.github/workflows/release.yaml@main
+  release_automation_hub:
+    uses: ansible/ansible-content-actions/.github/workflows/release_ah.yaml@main
     with:
       environment: release
       ah_publish: false
+  release_galaxy:
+    uses: ansible/ansible-content-actions/.github/workflows/release_galaxy.yaml@main
+    needs:
+      - release_automation_hub
+    with:
+      environment: release
     secrets:
       ansible_galaxy_api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}


### PR DESCRIPTION
Divided the release workflow into `release_automation_hub` and `release_galaxy` jobs to fix the issue with `ah_publish` being disabled.