### PR TITLE
Add FUNDING.yml file for GitHub sponsor info

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: nikitamishagin


### PR DESCRIPTION
Created a FUNDING.yml file to include GitHub sponsor details, enabling sponsor link display on the repository page.