### PR TITLE
Standardize workflow name in draft_release.yml

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,5 +1,5 @@
 ---
-name: "Draft release"
+name: "draft-release"
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Updated workflow `name` field to use "draft-release" to resolve execution errors caused by using spaces in the name.